### PR TITLE
Pin the cloud-native-core git hash to September 27th 2022 version

### DIFF
--- a/cloud-scripts/scripts/install-cnc.sh
+++ b/cloud-scripts/scripts/install-cnc.sh
@@ -23,6 +23,7 @@
 
 git clone https://github.com/NVIDIA/cloud-native-core
 cd cloud-native-core/playbooks
+git checkout 24b8bb23fc8fc8bae0d88c8d6f23169204c4b8cc
 cat << EOF > hosts
 [master]
 localhost ansible_connection=local


### PR DESCRIPTION
Recent changes to cnc appear to break the cloud scripts. Pin to the hash from 9/27/2022 for a stable version.