### PR TITLE
Patch install-cnc.sh to use ansible 6.0.0

### DIFF
--- a/cloud-scripts/scripts/install-cnc.sh
+++ b/cloud-scripts/scripts/install-cnc.sh
@@ -31,4 +31,5 @@ EOF
 cat << EOF > cnc_version.yaml
 cnc_version: 8.0
 EOF
+sed -i 's,pip3 install ansible,pip3 install ansible==6.0.0,g' setup.sh
 ./setup.sh install


### PR DESCRIPTION
This is a workaround for a deprecated parameter in ansible 7.0.0 that causes cloud-native-stack to fail.