### PR TITLE
Add option to disable creation of the cuopt security group

### DIFF
--- a/cloud-scripts/aws/terraform.tfvars
+++ b/cloud-scripts/aws/terraform.tfvars
@@ -26,26 +26,45 @@
 
 # Optional settings
 
+# Whether or not to create a new security group for the cuOpt server
+# Port 22 for ssh and ports 30000 and/or 30001 for the cuOpt API and Jupyter servers must be reachable.
+# If your default network has default rules to allow access to these ports, this value may be set to false.
+# If your account has existing security groups that allow access to these ports, this value may be set to false
+# if you also set additional_security_groups to include those existing security groups.
+# If your account does not have permission to create new security groups, then set this value to false and
+# ask an admin to create default network rules or additional security groups to allow these ports.
+#create_security_group = false
+
+# Has no effect if create_security_group = false
 # List of CIDR block values for addresses allowed to connect to the ssh port.
 # If installing from a cloud shell, the public IP address of the cloud shell must be included here
 # Individual IP addresses must be expressed as CIDRs in the form 1.2.3.4/32
 #ssh_cidr_blocks = ["0.0.0.0/0"]
 
+# Has no effect if create_security_group = false
 # List of CIDR block values for addresses allowed to connect to the cuOpt server.
 # Individual IP addresses must be expressed as CIDRs in the form 1.2.3.4/32
-# More info at https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group
 #cuopt_server_cidr_blocks = ["0.0.0.0/0"]
 
-# Additional notes on CIDR blocks
+# Has no effect if create_security_group = false
+# List of CIDR block values for outgoing traffic on all ports.
+# Individual IP addresses must be expressed as CIDRs in the form 1.2.3.4/32
+#outgoing_cidr_blocks = ["0.0.0.0/0"]
 
+# Additional notes on CIDR blocks
+# More info at https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/security_group
+
+# Has no effect if create_security_group = false
 # If your default network has default rules for port 22 that you would like to use instead,
 # set this value to [] to prevent creation of the rule for port 22.
 #ssh_cidr_blocks = []
 
+# Has no effect if create_security_group = false
 # If your default network has default rules for ports 30000-30001 that you would like to use instead,
 # set this value to [] to prevent creation of the rule for ports 30000-30001
 #cuopt_server_cidr_blocks = []
 
+# Has no effect if create_security_group = false
 # If your default network has default rules for outgoing traffic that you would like to use instead,
 # set this value to [] to prevent creation of the rule for outgoing traffic (default unrestricted)
 #outgoing_cidr_blocks = []

--- a/cloud-scripts/aws/variables.tf
+++ b/cloud-scripts/aws/variables.tf
@@ -67,6 +67,12 @@ variable "additional_security_groups" {
   default     = []
 }
 
+variable "create_security_group" {
+  description = "Whether or not to create a new security group for cuOpt. Security groups created outside of Terraform may be listed in additional_security_groups."
+  type = bool
+  default = true
+}
+
 variable "instance_ami_name" {
   description = "The pattern(s) used to filter available AMIs by name to select an image for the instance. May include wildcards."
   type        = list


### PR DESCRIPTION
Some AWS accounts may have permissions to create security groups turned off.  In this case, a user can request that an admin create a permanent security group that opens ssh and the cuopt ports appropriately, include that security group with "additional_security_groups", and turn off creation of the cuopt security group by terraform.