### PR TITLE
Add a check for Python3 and validate NGC api key (with helm)

### DIFF
--- a/cloud-scripts/utilities/parse.py
+++ b/cloud-scripts/utilities/parse.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 
 # SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT


### PR DESCRIPTION
If helm is installed, the script will validate the api key by fetching the cuopt helm chart. If the fetch fails, the key is invalid and the script exits early.