### PR TITLE
Add flags to cuopt-helm.sh for setting namespace, nodeports and server type

### DIFF
--- a/cloud-scripts/README.md
+++ b/cloud-scripts/README.md
@@ -206,7 +206,11 @@ To allow ssh access from a host other than the build host:
 
 * Edit the `~/.ssh/authorized_keys` file on the server and paste the new public key contents into the file on a new line
 
-### Running more than one cuOpt server on the same cloud
+### Options for Running more than one cuOpt server
+
+There are two options for running multiple cuOpt servers if you need to solve multiple problems simultaneously: use the cloud scripts to build an additional VM, or log into an existing server and launch an additional instance of cuOpt on the same machine. Note that multiple cuOpt instances on the same machine will share resources, so you should try your workload in this configuration to verify if one VM will be sufficient for your case.
+
+#### Running a Separate VM using cloud scripts
 
 Terraform will track resources that it creates and destroys in the directory where it is run. This means that each directory is tied to at most a single machine. If you would like to run more than one instance of cuOpt on the same cloud, you should copy the `*.tf` and `*.tfvars` files for that cloud to another directory. For example
 
@@ -215,6 +219,26 @@ $ mkdir aws_two
 $ cp aws/*.tf aws/*.tfvars aws_two
 $ cd aws_two
 ```
+
+#### Running additional instances of cuOpt on an existing server
+
+Log into the server and use the `cuopt-helm.sh` script to start another instance of cuOpt in a new namespace. Nodeports must be specified for the new instance since the defaults of 30000/30001 cannot be reused. If you did not modify the list of cuOpt ports to open in `terraform.tfvars` before you created the VM, only the default ports will be open and you will have to edit the firewall rules for the VM to allow new ports (see the documentation for your cloud provider on how to do this through the console or CLI).
+
+From the server:
+```bash
+$ cd scripts/
+$ export API_KEY=<my valid NGC api-key>
+$ ./cuopt-helm.sh -s 30002 -j 30003 -n cuopt-two # start a new instance in the cuopt-two namespace with the api server on port 30002 and the notebook server on 30003
+```
+
+With the current helm chart, both ports must always be set even if only the API server or notebook server is deployed; this will be fixed in a future version.
+
+For additional options to set the server type and the cuOpt chart version see the help:
+```
+$ ./cuopt-helm.sh -h
+```
+
+Note that this `cuopt-helm.sh` script may also be used standalone to start cuOpt on any Kubernetes cluster where the NVIDIA GPU operator has been installed.
 
 ## Cloud Local
 

--- a/cloud-scripts/scripts/cuopt-helm.sh
+++ b/cloud-scripts/scripts/cuopt-helm.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# SPDX-FileCopyrightText: Copyright (c) 2022 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# SPDX-FileCopyrightText: Copyright (c) 2022-2023 NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 # SPDX-License-Identifier: MIT
 
 # Permission is hereby granted, free of charge, to any person obtaining a
@@ -21,22 +21,80 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-NAMESPACE=cuopt-server
+# Call these out so we can reference them easily
+SERVER_DEFAULT=30000
+NOTEBOOK_DEFAULT=30001
+CHART_DEFAULT="cuopt-22.12.0.tgz"
+
+CUOPT_CHART=${CUOPT_CHART:-"$CHART_DEFAULT"}
+NAMESPACE=${NAMESPACE:-cuopt-server}
+NODE_PORT_SERVER=${NODE_PORT_SERVER:-"$SERVER_DEFAULT"}
+NODE_PORT_NOTEBOOK=${NODE_PORT_NOTEBOOK:-"$NOTEBOOK_DEFAULT"}
+SERVER_TYPE=${SERVER_TYPE:-"api"}
+
+function help {
+    echo "Convenience script for running the cuopt helm chart"
+    echo
+    echo "usage: cuopt-helm.sh [-h] [-n NAMESPACE] [-s NODE_PORT_SERVER]] [-j NODE_PORT_NOTEBOOK]] [-t SERVER_TYPE] [-c CUOPT_CHART]"
+    echo
+    echo "options:"
+    echo "  -n NAMESPACE          Deploy the helm chart in the specified namespace (default is cuopt-server)"
+    echo "  -s NODE_PORT_SERVER   The nodeport to use for the cuopt API server if deployed (default 30000)"
+    echo "  -j NODE_PORT_NOTEBOOK The nodeport to use for the cuopt Jupyter server if deployed (default 30001)"
+    echo "  -t SERVER_TYPE        The type of server to deploy, may be 'api', 'jupyter', or 'both' (default api)"
+    echo "  -c CUOPT_CHART        The cuopt helm chart to use (default $CHART_DEFAULT)"
+}
+
+while getopts "hn:s:j:t:c:" option; do
+   case $option in
+      h) # display Help
+         help
+         exit;;
+      n)
+         NAMESPACE=$OPTARG;;
+      s)
+         NODE_PORT_SERVER=$OPTARG;;
+      j)
+         NODE_PORT_NOTEBOOK=$OPTARG;;
+      t)
+         SERVER_TYPE=$OPTARG;;
+      c)
+	 CUOPT_CHART=$OPTARG;;
+     \?) # Invalid option
+         echo "Error: Invalid option"
+         exit;;
+   esac
+done
+
+echo "Chart is: $CUOPT_CHART"
+echo "Namespace is: $NAMESPACE"
+echo "Server type is: $SERVER_TYPE"
+echo "API server port: $NODE_PORT_SERVER"
+echo "Jupyter server port: $NODE_PORT_NOTEBOOK"
+
 kubectl create namespace $NAMESPACE
 
-helm fetch https://helm.ngc.nvidia.com/nvidia/cuopt/charts/cuopt-22.12.0.tgz --username='$oauthtoken' --password=$API_KEY --untar
+if [ ! -d "$CUOPT_CHART" ]; then
+    helm fetch https://helm.ngc.nvidia.com/nvstaging/cuopt/charts/$CUOPT_CHART --username='$oauthtoken' --password=$API_KEY --untar
+fi
+
+# Always set the port for each service, even if the service is not enabled.
+# In a future version of the chart, this will not be necessary if the
+# service is not enabled.
+server_str="--set node_port_server=$NODE_PORT_SERVER"
+notebook_str="--set node_port_notebook=$NODE_PORT_NOTEBOOK"
 
 case $SERVER_TYPE in
   "jupyter")
-    helm install --namespace $NAMESPACE --set ngc.apiKey=$API_KEY --set enable_nodeport=true nvidia-cuopt-chart cuopt --values cuopt/values_notebook.yaml
+    helm install --namespace $NAMESPACE --set ngc.apiKey=$API_KEY --set enable_nodeport=true $server_str $notebook_str nvidia-cuopt-chart cuopt --values cuopt/values_notebook.yaml
     ;;
 
   "both")
-    helm install --namespace $NAMESPACE --set ngc.apiKey=$API_KEY --set enable_nodeport=true --set enable_notebook_server=true nvidia-cuopt-chart cuopt --values cuopt/values.yaml
+    helm install --namespace $NAMESPACE --set ngc.apiKey=$API_KEY --set enable_nodeport=true --set enable_notebook_server=true $server_str $notebook_str nvidia-cuopt-chart cuopt --values cuopt/values.yaml
     ;;
 
   # default to api server in all other cases
   *)
-    helm install --namespace $NAMESPACE --set ngc.apiKey=$API_KEY --set enable_nodeport=true nvidia-cuopt-chart cuopt --values cuopt/values.yaml
+    helm install --namespace $NAMESPACE --set ngc.apiKey=$API_KEY --set enable_nodeport=true $server_str $notebook_str nvidia-cuopt-chart cuopt --values cuopt/values.yaml
     ;;
 esac


### PR DESCRIPTION
This change makes it easier to deploy multiple instances of cuopt in kubernetes using the cuopt helm chart. The script takes arguments so that additional instances of cuopt may be started on the same host.

Default behavior of this script is unchanged.